### PR TITLE
部分使用面向协议的方式改写，对 `task` 的 API 使用做了微小的重新设计

### DIFF
--- a/Tiercel/Extensions/Array+Safe.swift
+++ b/Tiercel/Extensions/Array+Safe.swift
@@ -28,11 +28,27 @@ import Foundation
 
 
 extension Array {
-    public func safeObjectAtIndex(_ index: Int) -> Element? {
-        if index < self.count {
+    public func safeObject(at index: Int) -> Element? {
+        if index < count {
             return self[index]
         } else {
             return nil
         }
+    }
+}
+
+extension Array where Element: Equatable {
+    
+    static func - (lhs: Array, rhs: Array) -> Array? {
+        guard lhs.count != 0, rhs.count != 0 else { return nil }
+        var result = lhs
+        result.forEach { item in
+            if rhs.contains(where: { $0 == item }) {
+                if let index = result.index(of: item) {
+                    result.remove(at: index)
+                }
+            }
+        }
+        return result
     }
 }

--- a/Tiercel/General/TRCache.swift
+++ b/Tiercel/General/TRCache.swift
@@ -162,7 +162,7 @@ extension TRCache {
         return tasks
     }
 
-    internal func retrievTmpFile(_ task: TRDownloadTask) {
+    internal func retrieveTmpFile(_ task: TRDownloadTask) {
         ioQueue.sync {
             guard let tmpFileName = task.tmpFileName, !tmpFileName.isEmpty else { return }
             let path1 = (self.downloadTmpPath as NSString).appendingPathComponent(tmpFileName)

--- a/Tiercel/General/TRCache.swift
+++ b/Tiercel/General/TRCache.swift
@@ -152,13 +152,13 @@ extension TRCache {
     internal func retrieveAllTasks() -> [TRTask]? {
         let path = (self.downloadPath as NSString).appendingPathComponent("\(self.name)Tasks.plist")
         
-        let tasks = NSKeyedUnarchiver.unarchiveObject(withFile: path) as? [TRTask]
-        tasks?.forEach({ (task) in
-            task.cache = self
-            if task.status == .waiting || task.status == .running {
-                task.status = .suspended
+        let tasks = NSKeyedUnarchiver.unarchiveObject(withFile: path) as? [TRDownloadTask]
+        tasks?.forEach {
+            $0.cache = self
+            if $0.status == .waiting || $0.status == .running {
+                $0.status = .suspended
             }
-        })
+        }
         return tasks
     }
 

--- a/Tiercel/General/TRConfiguration.swift
+++ b/Tiercel/General/TRConfiguration.swift
@@ -28,25 +28,23 @@ import UIKit
 
 protocol Configuration {
     // 请求超时时间
-    var timeoutIntervalForRequest: Double { set get }
+    var timeoutIntervalForRequest: Double { get }
     
     // 最大并发数
-    var maxConcurrentTasksLimit: Int { set get }
+    var maxConcurrentTasksLimit: Int { get }
     
     // 是否允许蜂窝网络下载
-    var allowsCellularAccess: Bool { set get }
+    var allowsCellularAccess: Bool { get }
 }
 
 public struct TRDefaultConfiguration: Configuration {
-    var timeoutIntervalForRequest: Double
+    public let timeoutIntervalForRequest: Double
     
-    var maxConcurrentTasksLimit: Int
+    public let maxConcurrentTasksLimit: Int
     
-    var allowsCellularAccess: Bool
+    public let allowsCellularAccess: Bool
     
-    // 请求超时时间
-    
-    public init(timeoutIntervalForRequest: Double = 30.0,
+    init(timeoutIntervalForRequest: Double = 30.0,
                 maxConcurrentTasksLimit: Int = Int.max,
                 allowsCellularAccess: Bool = false) {
         self.timeoutIntervalForRequest = timeoutIntervalForRequest

--- a/Tiercel/General/TRConfiguration.swift
+++ b/Tiercel/General/TRConfiguration.swift
@@ -26,18 +26,32 @@
 
 import UIKit
 
-public struct TRConfiguration {
+protocol Configuration {
     // 请求超时时间
-    public var timeoutIntervalForRequest = 30.0
+    var timeoutIntervalForRequest: Double { set get }
     
     // 最大并发数
-    public var maxConcurrentTasksLimit = Int.max
+    var maxConcurrentTasksLimit: Int { set get }
     
     // 是否允许蜂窝网络下载
-    public var allowsCellularAccess = false
+    var allowsCellularAccess: Bool { set get }
+}
+
+public struct TRDefaultConfiguration: Configuration {
+    var timeoutIntervalForRequest: Double
     
-    public init() {
-        
+    var maxConcurrentTasksLimit: Int
+    
+    var allowsCellularAccess: Bool
+    
+    // 请求超时时间
+    
+    public init(timeoutIntervalForRequest: Double = 30.0,
+                maxConcurrentTasksLimit: Int = Int.max,
+                allowsCellularAccess: Bool = false) {
+        self.timeoutIntervalForRequest = timeoutIntervalForRequest
+        self.maxConcurrentTasksLimit = maxConcurrentTasksLimit
+        self.allowsCellularAccess = allowsCellularAccess
     }
     
 }

--- a/Tiercel/General/TRSessionDelegate.swift
+++ b/Tiercel/General/TRSessionDelegate.swift
@@ -34,7 +34,7 @@ internal class TRSessionDelegate: NSObject {
 
 extension TRSessionDelegate: URLSessionDownloadDelegate {
     public func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
-        manager?.didBecomeInvalidWithError(error)
+        manager?.didBecomeInvalidation(withError: error)
     }
     
     

--- a/Tiercel/General/TRTask.swift
+++ b/Tiercel/General/TRTask.swift
@@ -34,6 +34,150 @@ extension TRTask {
     }
 }
 
+protocol DownloadTask {
+    
+    var cache: TRCache { set get }
+    
+    var session: URLSession? { set get }
+    
+    var headers: [String: String]? { set get }
+    
+    var progressHandler: TRHandler<TRTask>? { set get }
+    
+    var successHandler: TRHandler<TRTask>? { set get }
+    
+    var failureHandler: TRHandler<TRTask>? { set get }
+    
+    var request: URLRequest? { set get }
+    
+    /// 开始下载一个任务
+    func start()
+    /// 暂停任务
+    func suspend(_ handler: TRHandler<TRTask>?)
+    /// 取消任务
+    func cancel(_ handler: TRHandler<TRTask>?)
+    /// 删除任务
+    func remove(completely: Bool, _ handler: TRHandler<TRTask>?)
+    
+}
+
+extension DownloadTask {
+    
+    func start() {}
+    
+    func suspend(_ handler: TRHandler<TRTask>?) {}
+    
+    func cancel(_ handler: TRHandler<TRTask>?) {}
+    
+    func remove(completely: Bool, _ handler: TRHandler<TRTask>?) {}
+}
+
+public struct DefaultTask: Codable {
+    
+    public let URLString: String
+    
+    enum CodingKeys: String, CodingKey {
+        case URLString
+        case currentURLString
+        case fileName
+        case headers
+        case startDate
+        case endDate
+        case totalBytes
+        case completedBytes
+        case status
+        case verificationCode
+        case verificationType
+        case validation
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        URLString = (try? container.decode(String.self, forKey: .URLString)) ?? ""
+        try? container.decode(String.self, forKey: .currentURLString)
+        try? container.decode(String.self, forKey: .fileName)
+        try? container.decode([String: String].self, forKey: .headers)
+        try? container.decode(Double.self, forKey: .startDate)
+        try? container.decode(Double.self, forKey: .endDate)
+        try? container.decode(Int64.self, forKey: .totalBytes)
+        try? container.decode(Int64.self, forKey: .completedBytes)
+        try? container.decode(String.self, forKey: .status)
+        try? container.decode(String.self, forKey: .verificationCode)
+        try? container.decode(Int.self, forKey: .verificationType)
+        try? container.decode(Int.self, forKey: .validation)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        let container = try encoder.container(keyedBy: CodingKeys.self)
+        
+    }
+}
+
+extension DefaultTask: DownloadTask {
+    var cache: TRCache {
+        get {
+            <#code#>
+        }
+        set {
+            <#code#>
+        }
+    }
+    
+    var session: URLSession? {
+        get {
+            <#code#>
+        }
+        set {
+            <#code#>
+        }
+    }
+    
+    var headers: [String : String]? {
+        get {
+            <#code#>
+        }
+        set {
+            <#code#>
+        }
+    }
+    
+    var progressHandler: TRHandler<TRTask>? {
+        get {
+            <#code#>
+        }
+        set {
+            <#code#>
+        }
+    }
+    
+    var successHandler: TRHandler<TRTask>? {
+        get {
+            <#code#>
+        }
+        set {
+            <#code#>
+        }
+    }
+    
+    var failureHandler: TRHandler<TRTask>? {
+        get {
+            <#code#>
+        }
+        set {
+            <#code#>
+        }
+    }
+    
+    var request: URLRequest? {
+        get {
+            <#code#>
+        }
+        set {
+            <#code#>
+        }
+    }
+}
+
 
 public class TRTask: NSObject, NSCoding {
 


### PR DESCRIPTION
1. `TRConfiguration` 重命名为了 `TRDefaultConfiguration` 结构体，并用 POP 的方式进行了重新设计；
2. `TRDownloadTask` 类的 API 做了调整，在创建时直接生成 **成功**，**进度**，**失败**等监听的回调，设计灵感来源于 Kingfisher 和 AFNetworking 框架；
3. 其他一些写法上的微小改动。

ps: 计划将您的 `TRTask` 和 `TRDownloadTask` 类改成 struct 并采用面向协议的方式，但改动太大，设计上有很多需要调整，所以先放弃了 😂

写的不好，如有设计模式上的冒犯，还请海涵~