### PR TITLE
新增 cache路径自定义支持

### DIFF
--- a/Tiercel/General/Cache.swift
+++ b/Tiercel/General/Cache.swift
@@ -54,7 +54,7 @@ public class Cache {
     ///
     /// - Parameters:
     ///   - name: 不同的name，代表不同的下载模块，对应的文件放在不同的地方
-    public init(_ name: String) {
+    public init(_ name: String, _ downloadPath: String? = nil, _ downloadTmpPath: String? = nil, _ downloadFilePath: String? = nil) {
 
         self.identifier = name
         
@@ -65,11 +65,13 @@ public class Cache {
         
         let diskCachePath = Cache.defaultDiskCachePathClosure(cacheName)
         
-        downloadPath = (diskCachePath as NSString).appendingPathComponent("Downloads")
-
-        downloadTmpPath = (downloadPath as NSString).appendingPathComponent("Tmp")
+        let cachePath = downloadPath ?? (diskCachePath as NSString).appendingPathComponent("Downloads")
         
-        downloadFilePath = (downloadPath as NSString).appendingPathComponent("File")
+        self.downloadPath = cachePath
+
+        self.downloadTmpPath = downloadTmpPath ?? (cachePath as NSString).appendingPathComponent("Tmp")
+        
+        self.downloadFilePath = downloadFilePath ?? (cachePath as NSString).appendingPathComponent("File")
         
         createDirectory()
 
@@ -83,6 +85,14 @@ public class Cache {
 // MARK: - file
 extension Cache {
     internal func createDirectory() {
+        
+        if !fileManager.fileExists(atPath: downloadPath) {
+            do {
+                try fileManager.createDirectory(atPath: downloadPath, withIntermediateDirectories: true, attributes: nil)
+            } catch  {
+                TiercelLog("createDirectory error: \(error)", identifier: identifier)
+            }
+        }
 
         if !fileManager.fileExists(atPath: downloadTmpPath) {
             do {

--- a/Tiercel/General/SessionManager.swift
+++ b/Tiercel/General/SessionManager.swift
@@ -220,14 +220,15 @@ public class SessionManager {
     
     public init(_ identifier: String,
                 configuration: SessionConfiguration,
-                operationQueue: DispatchQueue = DispatchQueue(label: "com.Tiercel.SessionManager.operationQueue")) {
+                operationQueue: DispatchQueue = DispatchQueue(label: "com.Tiercel.SessionManager.operationQueue"),
+                cache: Cache? = nil) {
         let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.Daniels.Tiercel"
         self.identifier = "\(bundleIdentifier).\(identifier)"
         self._configuration = configuration
         self.operationQueue = operationQueue
-        cache = Cache(identifier)
-        cache.decoder.userInfo[.operationQueue] = operationQueue
-        tasks = cache.retrieveAllTasks()
+        self.cache = cache ?? Cache(identifier)
+        self.cache.decoder.userInfo[.operationQueue] = operationQueue
+        tasks = self.cache.retrieveAllTasks()
         tasks.forEach {
             $0.manager = self
             $0.operationQueue = operationQueue


### PR DESCRIPTION
SessionManager 可通过构造函数传值的方式自定义Cache 的文件路径, 文件路径参数值为可选, 为空时使用默认缓存路径